### PR TITLE
Add --skip-tags=packages to setup arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ LABEL name="manageiq-embedded-ansible" \
       io.openshift.tags="Ansible,ManageIQ"
 
 RUN yum -y remove ansible-tower-ui
+RUN yum -y install --setopt=tsflags=nodocs sudo && yum clean all
 
 COPY docker-assets/initialize-tower.sh /usr/bin

--- a/docker-assets/initialize-tower.sh
+++ b/docker-assets/initialize-tower.sh
@@ -29,4 +29,4 @@ rabbitmq_use_long_name=false
 rabbitmq_enable_manager=false
 EOF
 
-ansible-tower-setup -e minimum_var_space=0 -e tower_package_name=ansible-tower-server -i /inventory
+ansible-tower-setup -e minimum_var_space=0 -e tower_package_name=ansible-tower-server -i /inventory -- --skip-tags=packages


### PR DESCRIPTION
Previously the packages tag was installing the sudo package so we also need to install that here.

cc @simaishi 