### PR TITLE
Pass our options directly to ansible-playbook

### DIFF
--- a/docker-assets/initialize-tower.sh
+++ b/docker-assets/initialize-tower.sh
@@ -29,4 +29,4 @@ rabbitmq_use_long_name=false
 rabbitmq_enable_manager=false
 EOF
 
-ansible-tower-setup -e minimum_var_space=0 -e tower_package_name=ansible-tower-server -i /inventory -- --skip-tags=packages
+ansible-tower-setup -- --extra-vars=\{\"minimum_var_space\":0,\"tower_package_name\":\"ansible-tower-server\"\} --inventory=/inventory --skip-tags=packages


### PR DESCRIPTION
We are not using any options that the tower setup script needs
to know about so we can avoid bugs in that script by passing
the options directly to ansible-playbook in the format it expects.

This also makes the container run the same command line as we
do on the appliance.

https://bugzilla.redhat.com/show_bug.cgi?id=1516829