### PR TITLE
Use a single image

### DIFF
--- a/docker-assets/ansible-tower.repo
+++ b/docker-assets/ansible-tower.repo
@@ -1,0 +1,5 @@
+[ansible-tower]
+name=Ansible Tower - $basearch
+baseurl=http://releases.ansible.com/ansible-tower/rpm/epel-7-$basearch/
+enabled=1
+gpgcheck=0

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# dump docker container run variable into a file for systemd to load
+env > /container.env.vars
+
+echo "== Writing SECRET_KEY =="
+echo ${ANSIBLE_SECRET_KEY} > /etc/tower/SECRET_KEY
+
+# Wait for postgres to be up
+echo "== Checking ${DATABASE_SERVICE_NAME}:5432 status =="
+
+while true; do
+  /usr/bin/ncat ${DATABASE_SERVICE_NAME} 5432 < /dev/null && break
+  sleep 5
+done
+echo "${DATABASE_SERVICE_NAME}:5432 - accepting connections"
+
+exec "$@"

--- a/docker-assets/initialize-tower.service
+++ b/docker-assets/initialize-tower.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Initialize Ansible Tower
+After=network.service
+[Service]
+Type=oneshot
+EnvironmentFile=/container.env.vars
+ExecStart=/bin/initialize-tower.sh
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
We don't use the ansible tower container image and
anyone in the community will be using AWX now that it's released.

It doesn't really make sense to carry on with both of these images.

cc @simaishi this should look more like the downstream image now.